### PR TITLE
Fixes hardware issue with BCM2835 and wiring-pi

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,8 +1,9 @@
+
 {
   "simulatedData": false,
   "interval": 2000,
   "deviceId": "Raspberry Pi Node",
-  "LEDPin": 5,
+  "LEDPin": 18,
   "messageMax": 256,
   "credentialPath": "~/.iot-hub",
   "temperatureAlert": 30,

--- a/index.js
+++ b/index.js
@@ -7,8 +7,6 @@
 const fs = require('fs');
 const path = require('path');
 
-const wpi = require('wiring-pi');
-
 const Client = require('azure-iot-device').Client;
 const ConnectionString = require('azure-iot-device').ConnectionString;
 const Message = require('azure-iot-device').Message;
@@ -17,6 +15,8 @@ const Protocol = require('azure-iot-device-mqtt').Mqtt;
 const bi = require('az-iot-bi');
 
 const MessageProcessor = require('./messageProcessor.js');
+
+const gpio = require('rpi-gpio');
 
 var sendingMessage = true;
 var messageId = 0;
@@ -73,9 +73,9 @@ function receiveMessageCallback(msg) {
 
 function blinkLED() {
   // Light up LED for 500 ms
-  wpi.digitalWrite(config.LEDPin, 1);
+  gpio.write(config.LEDPin, true);
   setTimeout(function () {
-    wpi.digitalWrite(config.LEDPin, 0);
+    gpio.write(config.LEDPin, false);
   }, 500);
 }
 
@@ -112,9 +112,9 @@ function initClient(connectionStringParam, credentialPath) {
     return;
   }
 
-  // set up wiring
-  wpi.setup('wpi');
-  wpi.pinMode(config.LEDPin, wpi.OUTPUT);
+  // set up gpio
+  gpio.setup(config.LEDPin, gpio.DIR_OUT);
+  
   messageProcessor = new MessageProcessor(config);
 
   try {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "azure-iot-device": "1.1.7",
     "azure-iot-device-mqtt": "1.1.7",
     "bme280-sensor": "^0.1.6",
-    "wiring-pi": ">=2.1.1"
+    "rpi-gpio": "^1.0.0"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
The demo wasn't working anymore with Raspberry Pi3 Model B. "wiring-pi" is outdated and was replaced with "rpi-gpo".