### PR TITLE
Replaced wiring-pi for node-wiring-pi in dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const wpi = require('wiring-pi-node');
+const wpi = require('node-wiring-pi');
 
 const Client = require('azure-iot-device').Client;
 const ConnectionString = require('azure-iot-device').ConnectionString;

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const wpi = require('wiring-pi');
+const wpi = require('wiring-pi-node');
 
 const Client = require('azure-iot-device').Client;
 const ConnectionString = require('azure-iot-device').ConnectionString;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "azure-iot-device": "1.1.7",
     "azure-iot-device-mqtt": "1.1.7",
     "bme280-sensor": "^0.1.6",
-    "wiring-pi-node": "0.0.4"
+    "node-wiring-pi": "0.0.4"
   },
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "azure-iot-device": "1.1.7",
     "azure-iot-device-mqtt": "1.1.7",
     "bme280-sensor": "^0.1.6",
-    "wiring-pi": ">=2.1.1"
+    "wiring-pi-node": "0.0.4"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Modified the dependencies in package.json  it solves the error caused by incompatibility or wiring-pi with the newest raspbian system

"issues unable to determine hardware version. I see hardware BCM2835"

that is been reported on all these issues dating as far back as December 2017
#7 
#18
 #20 
https://github.com/MicrosoftDocs/azure-docs/issues/7392
https://github.com/Azure-Samples/iot-hub-node-raspberrypi-client-app/issues/15
https://github.com/MicrosoftDocs/azure-docs/issues/8128

@SLdragon  would you please review?

Thanks,

Alberto Vega