### PR TITLE
Update wiring-pi dependency and fix sendMessage interval

### DIFF
--- a/index.js
+++ b/index.js
@@ -202,7 +202,7 @@ function initClient(connectionStringParam, credentialPath) {
         }
         config.interval = twin.properties.desired.interval || config.interval;
       });
+      sendMessage();
     }, config.interval);
-    sendMessage();
   });
 })(process.argv[2]);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "eslint": "^3.17.1"
+    "eslint": "^6.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "azure-iot-device-mqtt": "^1.9.3",
     "azure-iot-device-amqp": "^1.9.3",
     "bme280-sensor": "^0.1.6",
-    "node-wiring-pi": "0.0.4"
+    "node-wiring-pi": "0.0.5"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Found 3 issues and fixed them:
- the reason folks encounter issues running the sample is because of an old wiring-pi dependency. it seems that installing the latest fixes the problem (Fix for #23) 
- the sendMessage function wasn't called at an interval (probably just a typo)
- there's a vulnerability warning with the old eslint version which i fixed by updating to the latest eslint version.

I also think the instructions in the tutorial make too liberal of a use of sudo so i'll suggest fixes separately for the docs.